### PR TITLE
Update core switch statement to hide embedded code by default

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,18 +1,19 @@
 {
-    "manifest_version": 3,
-    "name": "Social Media Blocks",
-    "description": "Developers don't talk much. Their code does all the talking. So here's a google chrome extension for developers that want to block big social media websites like Twitter: Facebook, Instagram, LinkedIn, WhatsApp, Reddit etc. Add this extension into your browser TODAY and achieve better productivity.",
-    "version" : "1.0.0",
-    "icons" : {"128": "./assets/images/logo128.png"},
-    "action": {
-        "default_icon": "./assets/images/logo16.png",
-        "default_popup": "./popup.html"
-    },
-    "content_scripts": [
-        {
-          "matches": ["<all_urls>"],
-          "js": ["popup.js"]
-        }
-      ],
-    "permissions": ["activeTab"]
+  "manifest_version": 3,
+  "name": "Social Media Blocks",
+  "description": "Developers don't talk much. Their code does all the talking. So here's a google chrome extension for developers that want to block big social media websites like Twitter: Facebook, Instagram, LinkedIn, WhatsApp, Reddit etc. Add this extension into your browser TODAY and achieve better productivity.",
+  "version": "1.0.1",
+  "icons": { "128": "./assets/images/logo128.png" },
+  "action": {
+    "default_icon": "./assets/images/logo16.png",
+    "default_popup": "./popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["popup.js"],
+      "all_frames": true
+    }
+  ],
+  "permissions": ["activeTab"]
 }

--- a/popup.html
+++ b/popup.html
@@ -1,40 +1,41 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <title>Social Media Blocks</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="assets/css/styles.css">
-  <title>Social Media Blocks</title>
-
-</head>
-
-<body>
+  <body>
     <div class="modal-header">
-        <h1 class="logo">
-            <img src="./assets/images/logo128.png" alt="Social Media Blocks" class="logo-icon">Social Media Blocks <span class="version">(1.0.0)</span>
-        </h1>
+      <h1 class="logo">
+        <img src="./assets/images/logo128.png" alt="Social Media Blocks" class="logo-icon" />Social Media Blocks <span class="version">(1.0.0)</span>
+      </h1>
     </div>
     <div class="modal-content">
-        <p> Early Access To Social Media Block !</p>
+      <p>Early Access To Social Media Block !</p>
     </div>
     <div class="modal-icons">
-        <div class="container">
-            <h3>How to access:</h3>
-            <ul>
-            <li>Clone this repo on <span><a href="https://github.com/JavascriptDon/Social-Media-Blocks-Extension" target="_blank">github</a></span>.</li>
-            <li>Go in to Google Chrome Extensions and turn Developer Mode on.</li>
-            <li>Click on Load Unpacked.</li>
-            <li>Select folder which contains content of this repos.</li>
-            <li>Click the switch button to turn extension on and it should work.</li>
-            </ul>
-        </div>
+      <div class="container">
+        <h3>How to access:</h3>
+        <ul>
+          <li>
+            Clone this repo on <span><a href="https://github.com/JavascriptDon/Social-Media-Blocks-Extension" target="_blank">github</a></span
+            >.
+          </li>
+          <li>Go in to Google Chrome Extensions and turn Developer Mode on.</li>
+          <li>Click on Load Unpacked.</li>
+          <li>Select folder which contains content of this repos.</li>
+          <li>Click the switch button to turn extension on and it should work.</li>
+        </ul>
+      </div>
     </div>
     <div id="modal-footer">
-        <a href="https://github.com/JavascriptDon/Social-Media-Blocks-Extension" target="_blank"><p>MIT © HR</p></a>
+      <a href="https://github.com/JavascriptDon/Social-Media-Blocks-Extension" target="_blank"><p>MIT © HR</p></a>
     </div>
-</body>
+  </body>
 
-<script src="popup.js"></script>
+  <script src="popup.js" type="module"></script>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,7 @@
+// ToDo: check for more hosts and set them optional
+
 const generateHTML = (pageName) => {
-    return `<div id="clouds">
+  return `<div id="clouds">
     <div class="cloud x1"></div>
     <div class="cloud x1_5"></div>
     <div class="cloud x2"></div>
@@ -18,10 +20,10 @@ const generateHTML = (pageName) => {
     <img src="https://images.vexels.com/media/users/3/152639/isolated/preview/506b575739e90613428cdb399175e2c8-space-astronaut-cartoon-by-vexels.png" alt="" class="src">
   </div>
   `;
-  };
-  
-  const generateSTYLING = () => {
-    return `<style>
+};
+
+const generateSTYLING = () => {
+  return `<style>
      body {
       margin: 0;
       padding: 0;
@@ -269,48 +271,75 @@ const generateHTML = (pageName) => {
       }
     }  
      </style>`;
-  };
-  
-  switch (window.location.hostname){
-    case "www.youtube.com":
-        document.head.innerHTML = generateSTYLING();
-        document.body.innerHTML = generateHTML('YOUTUBE');
-        break;
-    case "www.facebook.com":
-        document.head.innerHTML = generateSTYLING();
-        document.body.innerHTML = generateHTML('FACEBOOK');  
-        break;
-    case "www.netflix.com":
-        document.head.innerHTML = generateSTYLING();
-        document.body.innerHTML = generateHTML('NETFLIX'); 
-        break;
-    case "www.tiktok.com":
-        document.head.innerHTML = generateSTYLING();
-        document.body.innerHTML = generateHTML('TIKTOK');
-        break;
-    case "www.discord.com":
-        document.head.innerHTML = generateSTYLING();
-        document.body.innerHTML = generateHTML('DISCORD');
-        break;
-    case "www.instagram.com":
-        document.head.innerHTML = generateSTYLING();
-        document.body.innerHTML = generateHTML('INSTAGRAM');
-        break;
-    case "web.whatsapp.com":
-        document.head.innerHTML = generateSTYLING();
-        document.body.innerHTML = generateHTML('WHATSAPP');
-        break;
-    case "www.linkedin.com":
-        document.head.innerHTML = generateSTYLING();
-        document.body.innerHTML = generateHTML('LINKEDIN');
-        break;
-    case "www.twitter.com":
-        document.head.innerHTML = generateSTYLING();
-        document.body.innerHTML = generateHTML('TWITTER');
-        break;
-    case "www.reddit.com":
-        document.head.innerHTML = generateSTYLING();
-        document.body.innerHTML = generateHTML('REDDIT');
-        break;
-    
-  };
+};
+
+/** @type {Object} */
+const HOSTS = [
+  'www.youtube.com',
+  'www.youtube.com',
+  'www.netflix.com',
+  'www.tiktok.com',
+  'www.instagram.com',
+  'web.whatsapp.com',
+  'www.linkedin.com',
+  'www.twitter.com',
+  'www.reddit.com',
+];
+
+/**
+ * Search for embedded content to hide inside websites
+ */
+const searchForEmbeddedContent = () => {
+  const contextIframes = [].slice.call(document.querySelectorAll('iframe'));
+
+  for (const iframe of contextIframes) {
+    for (const host in HOSTS) {
+      if (iframe.getAttribute('src')?.includes(host)) iframe.style.display = 'none';
+    }
+  }
+};
+
+switch (window.location.hostname) {
+  case 'www.youtube.com':
+    document.head.innerHTML = generateSTYLING();
+    document.body.innerHTML = generateHTML('YOUTUBE');
+    break;
+  case 'www.youtube.com':
+    document.head.innerHTML = generateSTYLING();
+    document.body.innerHTML = generateHTML('FACEBOOK');
+    break;
+  case 'www.netflix.com':
+    document.head.innerHTML = generateSTYLING();
+    document.body.innerHTML = generateHTML('NETFLIX');
+    break;
+  case 'www.tiktok.com':
+    document.head.innerHTML = generateSTYLING();
+    document.body.innerHTML = generateHTML('TIKTOK');
+    break;
+  case 'www.discord.com':
+    document.head.innerHTML = generateSTYLING();
+    document.body.innerHTML = generateHTML('DISCORD');
+    break;
+  case 'www.instagram.com':
+    document.head.innerHTML = generateSTYLING();
+    document.body.innerHTML = generateHTML('INSTAGRAM');
+    break;
+  case 'web.whatsapp.com':
+    document.head.innerHTML = generateSTYLING();
+    document.body.innerHTML = generateHTML('WHATSAPP');
+    break;
+  case 'www.linkedin.com':
+    document.head.innerHTML = generateSTYLING();
+    document.body.innerHTML = generateHTML('LINKEDIN');
+    break;
+  case 'www.twitter.com':
+    document.head.innerHTML = generateSTYLING();
+    document.body.innerHTML = generateHTML('TWITTER');
+    break;
+  case 'www.reddit.com':
+    document.head.innerHTML = generateSTYLING();
+    document.body.innerHTML = generateHTML('REDDIT');
+    break;
+  default:
+    searchForEmbeddedContent();
+}


### PR DESCRIPTION
If no case is true, then we are not in any of those websites.
In such cases, we still can get content from them. it now search for embedded content from those hosts and hide it.

Feel free to cover them with any other extension-related graphics if you want.

Already tested navigating through forums and websites I usually use.

A nice to have would be a way to configure which hosts to hide/block instead getting all of them blocked, specially when you use some of those tools to work.
